### PR TITLE
Fix: Hydration errors caused by the navbar

### DIFF
--- a/src/app/_components/navbar.tsx
+++ b/src/app/_components/navbar.tsx
@@ -160,7 +160,7 @@ export function Navbar() {
       {/* Mobile Nav */}
       <div className="md:hidden">
         <Sheet open={open} onOpenChange={setOpen}>
-          <SheetTrigger asChild>
+          <SheetTrigger asChild aria-controls="radix-_R_46atnlb_">
             <Button variant="outline" size="icon" aria-label="Open menu">
               <svg
                 className="h-5 w-5"


### PR DESCRIPTION
The attached image displays the Next.js error on the homepage.
The issue was fixed by setting the `aria-controls` attribute to the value on the server directly.

<img width="695" height="597" alt="{D33A11A7-E1D1-4843-9BA7-A52DB9C537F3}" src="https://github.com/user-attachments/assets/ac7d1d88-ffc8-4871-8c7e-b6c97c06ea62" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Mobile navigation trigger now includes an aria-controls attribute to improve screen reader context for the related sheet region.

* **Style**
  * No visual or behavioral changes; markup improvement only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->